### PR TITLE
Add squeezelite support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN pip install git+https://github.com/LedFx/LedFx
 RUN apt-get install -y pulseaudio alsa-utils
 RUN adduser root pulse-access
 
+RUN apt-get install -y squeezelite 
+
 COPY setup-files/ /app/
 RUN chmod a+wrx /app/*
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ services:
     environment: 
       - HOST=host.docker.internal
       - FORMAT=-r 44100 -f S16_LE -c 2
+      - SQUEEZE=1
     ports:
       - 8888:8888
     volumes:
@@ -39,10 +40,11 @@ Variable | Function
 --- | --------
 `HOST` | This is the IP of the Snapcast server. Keep in mind that this IP is resolved from inside the container unless you use [host networking](https://docs.docker.com/network/host/). To refer to other docker containers in [bridge networking](https://docs.docker.com/network/bridge/) (the default for any two containers in the same compose file), just use the name of the container. To refer to `127.0.0.1` use `host.docker.internal`. 
 `FORMAT` | This variable specifies the format of the audio coming into `/app/audio/stream`. It can use any of the options defined in [aplay](https://linux.die.net/man/1/aplay). The example shown above corresponds to 44100hz, 16 bits, and 2 channels, the default for most applications. 
+`SQUEEZE` | Setting this variable to `1` allows this image to act as a [squeezelite](https://github.com/ralph-irving/squeezelite) client that can connect to a [Logitech Media Server](https://mysqueezebox.com/download).
 
 ## Sending Audio
 
-The trickiest part of using this image is getting audio into it. Dealing with audio device drivers is pretty painful; so much so that I spent 20 minutes getting LedFx installed and 50 hours squashing audio bugs. Don't worry, that work has already been done, so here are three approaches to get audio into the container:
+The trickiest part of using this image is getting audio into it. Dealing with audio device drivers is pretty painful; so much so that I spent 20 minutes getting LedFx installed and 50 hours squashing audio bugs. Don't worry, that work has already been done, so here are four approaches to get audio into the container:
 
 ### Snapcast
 
@@ -59,6 +61,10 @@ To play system audio, you could use Docker's `--device` flag or use FFmpeg to re
 If you want to use a method not mentioned here or one that doesn't have an explicit named pipe option, your easiest method would probably be playing the audio on the system; then use a tool like FFmpeg or PulseAudio to record the system's audio and send it to the container. 
 
 Check out the `examples/` folder for ideas. Once you've completed your setup, consider sharing your compose file; I'm always looking for new examples to add. 
+
+### Logitech Media Server
+
+You can send in audio from a [Logitech Media Server](https://mysqueezebox.com/download). You'll need to set the environment variable `SQUEEZE=1`. There's a docker example of this in the `examples/` folder. To connect, simply setup your Logitech Media Server on the same network as this container, and your server will automatically detect the LedFx as a client and provide an option to connect. If your media server is on a different network or is not detecting LedFx, you can configure `squeeze.conf` in the `setup-files/` folder and build the container locally.
 
 ### Balena Sound
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment: 
       - HOST=host.docker.internal
       - FORMAT=-r 44100 -f S16_LE -c 2
+      - SQUEEZE=0
     ports:
       - 8888:8888
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment: 
       - HOST=host.docker.internal
       - FORMAT=-r 44100 -f S16_LE -c 2
-      - SQUEEZE=0
+      - SQUEEZE=1
     ports:
       - 8888:8888
     volumes:

--- a/examples/lms-squeezelite.yml
+++ b/examples/lms-squeezelite.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  ledfx:
+    image: shirom/ledfx
+    container_name: ledfx
+    environment: 
+      - SQUEEZE=1
+    ports:
+      - 8888:8888
+    volumes:
+      - ./ledfx-config:/app/ledfx-config
+      - ~/audio:/app/audio
+  lms:
+    container_name: lms
+    image: lmscommunity/logitechmediaserver
+    volumes:
+      - ./lms/config:/config:rw
+      - ./lms/music:/music:ro
+      - ./lms/playlist:/playlist:ro
+    ports:
+      - 9000:9000/tcp
+      - 9090:9090/tcp

--- a/setup-files/entrypoint.sh
+++ b/setup-files/entrypoint.sh
@@ -13,6 +13,7 @@ if [[ -v HOST ]]; then
     ./snapcast.sh
 fi
 
+mv -vn /app/squeeze.conf /app/ledfx-config/
 if [[ -v SQUEEZE ]]; then
     ./squeeze.sh
 fi

--- a/setup-files/entrypoint.sh
+++ b/setup-files/entrypoint.sh
@@ -13,11 +13,11 @@ if [[ -v HOST ]]; then
     ./snapcast.sh
 fi
 
+mkdir /app/ledfx-config
 mv -vn /app/squeeze.conf /app/ledfx-config/
 if [[ -v SQUEEZE ]]; then
     ./squeeze.sh
 fi
 
-mkdir /app/ledfx-config
 mv -vn /app/config.yaml /app/ledfx-config/
 ledfx -c /app/ledfx-config 

--- a/setup-files/entrypoint.sh
+++ b/setup-files/entrypoint.sh
@@ -14,7 +14,7 @@ if [[ -v HOST ]]; then
 fi
 
 mkdir /app/ledfx-config
-mv -vn /app/squeeze.conf /app/ledfx-config/
+
 if [[ -v SQUEEZE ]]; then
     ./squeeze.sh
 fi

--- a/setup-files/entrypoint.sh
+++ b/setup-files/entrypoint.sh
@@ -13,6 +13,10 @@ if [[ -v HOST ]]; then
     ./snapcast.sh
 fi
 
+if [[ -v SQUEEZE ]]; then
+    ./squeeze.sh
+fi
+
 mkdir /app/ledfx-config
 mv -vn /app/config.yaml /app/ledfx-config/
 ledfx -c /app/ledfx-config 

--- a/setup-files/entrypoint.sh
+++ b/setup-files/entrypoint.sh
@@ -13,11 +13,11 @@ if [[ -v HOST ]]; then
     ./snapcast.sh
 fi
 
-mkdir /app/ledfx-config
-
 if [[ -v SQUEEZE ]]; then
     ./squeeze.sh
 fi
+
+mkdir /app/ledfx-config
 
 mv -vn /app/config.yaml /app/ledfx-config/
 ledfx -c /app/ledfx-config 

--- a/setup-files/squeeze.conf
+++ b/setup-files/squeeze.conf
@@ -1,0 +1,19 @@
+# Defaults for squeezelite initscript
+# sourced by /etc/init.d/squeezelite
+# installed at /etc/default/squeezelite by the maintainer scripts
+
+# The name for the squeezelite player:
+SL_NAME="$(hostname -s)"
+
+# ALSA output device:
+#SL_SOUNDCARD="default:CARD=Set"
+
+# Squeezebox server (Logitech Media Server):
+# Uncomment the next line if you want to point squeezelite at the IP address of
+# your squeezebox server. This is usually unnecessary as the server is
+# automatically discovered.
+#SB_SERVER_IP="192.168.x.y"
+
+# Additional options to pass to squeezelite:
+# Please do not include -z to make squeezelite daemonise itself.
+#SB_EXTRA_ARGS=""

--- a/setup-files/squeeze.sh
+++ b/setup-files/squeeze.sh
@@ -1,5 +1,5 @@
 if [ "$SQUEEZE" == "1" ]; then
       apt-get install -fy squeezelite
       cp -v /app/ledfx-config/ /etc/default/squeezelite
-      squeezelite -z
+      /etc/init.d/squeezelite start
 fi

--- a/setup-files/squeeze.sh
+++ b/setup-files/squeeze.sh
@@ -1,5 +1,6 @@
 if [ "$SQUEEZE" == "1" ]; then
-      apt-get install -fy squeezelite
-      cp -v /app/ledfx-config/ /etc/default/squeezelite
-      /etc/init.d/squeezelite start
+    mv -vn /app/squeeze.conf /app/ledfx-config/
+    apt-get install -fy squeezelite
+    cp -v /app/ledfx-config/ /etc/default/squeezelite
+    /etc/init.d/squeezelite start
 fi

--- a/setup-files/squeeze.sh
+++ b/setup-files/squeeze.sh
@@ -1,6 +1,5 @@
 if [ "$SQUEEZE" == "1" ]; then
     mv -vn /app/squeeze.conf /app/ledfx-config/
-    apt-get install -fy squeezelite
     cp -v /app/ledfx-config/squeeze.conf /etc/default/squeezelite
     /etc/init.d/squeezelite start
 fi

--- a/setup-files/squeeze.sh
+++ b/setup-files/squeeze.sh
@@ -1,0 +1,4 @@
+if [ "$SQUEEZE" == "1" ]; then
+      apt-get install -fy squeezelite
+      squeezelite -z
+fi

--- a/setup-files/squeeze.sh
+++ b/setup-files/squeeze.sh
@@ -1,4 +1,5 @@
 if [ "$SQUEEZE" == "1" ]; then
       apt-get install -fy squeezelite
+      cp -v /app/squeeze.conf /etc/default/squeezelite
       squeezelite -z
 fi

--- a/setup-files/squeeze.sh
+++ b/setup-files/squeeze.sh
@@ -1,6 +1,6 @@
 if [ "$SQUEEZE" == "1" ]; then
     mv -vn /app/squeeze.conf /app/ledfx-config/
     apt-get install -fy squeezelite
-    cp -v /app/ledfx-config/ /etc/default/squeezelite
+    cp -v /app/ledfx-config/squeeze.conf /etc/default/squeezelite
     /etc/init.d/squeezelite start
 fi

--- a/setup-files/squeeze.sh
+++ b/setup-files/squeeze.sh
@@ -1,5 +1,5 @@
 if [ "$SQUEEZE" == "1" ]; then
       apt-get install -fy squeezelite
-      cp -v /app/squeeze.conf /etc/default/squeezelite
+      cp -v /app/ledfx-config/ /etc/default/squeezelite
       squeezelite -z
 fi


### PR DESCRIPTION
Squeezelite is a client for the multiroom software Logitech Media Server.
This pull request installs squeezelite in Docker with the environment variable SQUEEZE=1 and starts it automatically.
