### PR TITLE
Update Docker image to Debian 13

### DIFF
--- a/.github/workflows/dockerhub-push-latest.yml
+++ b/.github/workflows/dockerhub-push-latest.yml
@@ -1,44 +1,46 @@
-name: Push latest tag to DockerHub 
+name: Push latest tag to DockerHub
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
     paths:
       - Dockerfile
       - setup-files/**
+      - .github/workflows/dockerhub-push-latest.yml
   pull_request:
-    branches: [ master ]
+    branches: [master]
     paths:
       - Dockerfile
       - setup-files/**
-
+      - .github/workflows/dockerhub-push-latest.yml
   workflow_dispatch:
 
-# https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md
 jobs:
   build-push:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1 
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
           tags: shirom/ledfx:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,31 @@
-FROM python:3.9-buster
-
+FROM python:3.12-trixie AS primary
 WORKDIR /app
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH=/opt/venv/bin:$PATH
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN pip install Cython
-RUN dpkg --add-architecture armhf
 RUN apt-get update
-RUN apt-get install -y gcc \
-                       git \
-                       libatlas3-base \
-		       libavformat58 \
-		       portaudio19-dev \
-		       avahi-daemon \
-		       pulseaudio
-RUN pip install --upgrade pip wheel setuptools
-RUN pip install lastversion
-RUN pip install git+https://github.com/LedFx/LedFx
+RUN apt-get install -y --no-install-recommends \
+	libportaudio2 \
+	avahi-daemon \
+	alsa-utils \
+	libnss-mdns \
+	libavahi-client3 \
+	libavahi-common3 \
+	libvorbisidec1 \
+	pulseaudio \
+	pulseaudio-utils \
+	squeezelite \
+	cmake \
+	gcc
 
-RUN apt-get install -y alsa-utils
+RUN python -m venv "$VIRTUAL_ENV"
+RUN pip install --no-cache-dir --upgrade pip wheel setuptools numpy
+RUN pip install --no-cache-dir LedFx
+
 RUN adduser root pulse-access
 
-# https://gnanesh.me/avahi-docker-non-root.html
-RUN apt-get install -y libnss-mdns
+# https://web.archive.org/web/20230527143933/https://gnanesh.me/avahi-docker-non-root.html
 RUN echo '*' > /etc/mdns.allow \
 	&& sed -i "s/hosts:.*/hosts:          files mdns4 dns/g" /etc/nsswitch.conf \
 	&& printf "[server]\nenable-dbus=no\n" >> /etc/avahi/avahi-daemon.conf \
@@ -29,21 +34,20 @@ RUN echo '*' > /etc/mdns.allow \
 	&& chown avahi:avahi /var/run/avahi-daemon \
 	&& chmod 777 /var/run/avahi-daemon
 
-RUN apt-get install -y wget \
-                       libavahi-client3:armhf \
-                       libavahi-common3:armhf \
-                       apt-utils \
-		       libvorbisidec1:armhf
-
-RUN apt-get install -y squeezelite 
-
+# Get snapcast.deb for correct platform and copy to primary context
+FROM primary AS snapcast
+RUN pip install --no-cache-dir lastversion
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=armhf; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=armhf; else ARCHITECTURE=amd64; fi \
-    && lastversion download badaix/snapcast --format assets --filter "^snapclient_(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\-)?(?:(\d)(_$ARCHITECTURE\.deb))$" -o snapclient.deb
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi \
+	&& lastversion download badaix/snapcast --format assets --filter "^snapclient_(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\-)?(?:(\d)(_$ARCHITECTURE\_trixie_with-pulse.deb))$" -o snapclient.deb
 
-RUN apt-get install -fy ./snapclient.deb
+FROM primary
+ARG DEBIAN_FRONTEND=noninteractive
+COPY --from=snapcast /app/snapclient.deb .
+RUN apt-get install -fy ./snapclient.deb \
+	&& rm snapclient.deb
 
 COPY setup-files/ /app/
 RUN chmod a+wrx /app/*
 
-ENTRYPOINT ./entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/setup-files/entrypoint.sh
+++ b/setup-files/entrypoint.sh
@@ -1,27 +1,89 @@
 #!/bin/bash
+set -e
+
+export VIRTUAL_ENV="${VIRTUAL_ENV:-/opt/venv}"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
+export PULSE_SERVER="${PULSE_SERVER:-unix:/run/pulse/native}"
+PULSE_SINK="${PULSE_SINK:-ledfx_snapcast}"
+PULSE_SOURCE="${PULSE_SOURCE:-$PULSE_SINK.monitor}"
 
 # Start avahi daemon for WLED auto discovery
-avahi-daemon --daemonize --no-drop-root
+mkdir -p /run/avahi-daemon
+rm -f /run/avahi-daemon/pid
+chown avahi:avahi /run/avahi-daemon || true
+if ! avahi-daemon --daemonize --no-drop-root; then
+    echo "Warning: avahi-daemon failed to start; WLED auto discovery may not work." >&2
+fi
 
 # https://superuser.com/questions/1539634/pulseaudio-daemon-wont-start-inside-docker
 # Start the pulseaudio server
 rm -rf /var/run/pulse /var/lib/pulse /root/.config/pulse
-pulseaudio -D --verbose --exit-idle-time=-1 --system --disallow-exit
-
-if [[ -v FORMAT ]]; then
-    ./pipe-audio.sh
+if ! pulseaudio -D --exit-idle-time=-1 --system --disallow-exit --disallow-module-loading \
+    -L "module-null-sink sink_name=$PULSE_SINK sink_properties=device.description=LedFxSnapcast"; then
+    echo "Warning: pulseaudio failed to start; audio input may not work." >&2
 fi
 
-if [[ -v HOST ]]; then
-    snapclient --host "$HOST" --daemon 1
+for _ in {1..20}; do
+    [[ -S /run/pulse/native ]] && break
+    sleep 0.1
+done
+
+if command -v pactl >/dev/null 2>&1; then
+    pactl set-default-sink "$PULSE_SINK" || echo "Warning: could not set PulseAudio default sink to '$PULSE_SINK'." >&2
+    pactl set-default-source "$PULSE_SOURCE" || echo "Warning: could not set PulseAudio default source to '$PULSE_SOURCE'." >&2
 fi
 
-if [[ -v SQUEEZE ]]; then
-    ./squeeze.sh
+if [[ -n "${FORMAT+x}" ]]; then
+    if ! ./pipe-audio.sh; then
+        echo "Warning: named pipe audio failed to start." >&2
+    fi
 fi
 
-mkdir /app/ledfx-config
+if [[ -n "${HOST+x}" ]]; then
+    SNAPCLIENT_PLAYER="${SNAPCLIENT_PLAYER:-pulse:server=$PULSE_SERVER}"
+    if [[ -n "${SNAPCLIENT_SERVER:-}" ]]; then
+        snapclient_server="$SNAPCLIENT_SERVER"
+    elif [[ "$HOST" == *"://"* ]]; then
+        snapclient_server="$HOST"
+    elif [[ "$HOST" == *":"* ]]; then
+        snapclient_server="tcp://$HOST"
+    else
+        snapclient_server="tcp://$HOST:${SNAPCLIENT_PORT:-1704}"
+    fi
 
-mv -vn /app/config.yaml /app/ledfx-config/
-mkdir /root/.ledfx
-ledfx -c /app/ledfx-config 
+    snapclient_args=(--player "$SNAPCLIENT_PLAYER")
+    if [[ -n "${SNAPCLIENT_OPTS:-}" ]]; then
+        read -r -a snapclient_extra_args <<< "$SNAPCLIENT_OPTS"
+        snapclient_args+=("${snapclient_extra_args[@]}")
+    fi
+    snapclient_args+=("$snapclient_server")
+
+    echo "Starting Snapclient for '$snapclient_server' with player '$SNAPCLIENT_PLAYER'..."
+    snapclient "${snapclient_args[@]}" &
+    snapclient_pid=$!
+    sleep 1
+    if ! kill -0 "$snapclient_pid" 2>/dev/null; then
+        echo "Warning: snapclient failed to start for server '$snapclient_server'." >&2
+    fi
+fi
+
+if [[ -n "${SQUEEZE+x}" ]]; then
+    if ! ./squeeze.sh; then
+        echo "Warning: squeezelite failed to start." >&2
+    fi
+fi
+
+mkdir -p /app/ledfx-config /root/.ledfx
+
+if [[ -f /app/config.yaml && ! -f /app/ledfx-config/config.yaml ]]; then
+    cp -v /app/config.yaml /app/ledfx-config/config.yaml
+fi
+
+if [[ ! -x "$VIRTUAL_ENV/bin/ledfx" ]]; then
+    echo "Error: LedFx executable not found at $VIRTUAL_ENV/bin/ledfx." >&2
+    ls -la "$VIRTUAL_ENV/bin" >&2 || true
+    exit 1
+fi
+
+echo "Starting LedFx..."
+exec "$VIRTUAL_ENV/bin/ledfx" -c /app/ledfx-config

--- a/setup-files/pipe-audio.sh
+++ b/setup-files/pipe-audio.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-rm /app/audio/stream
+mkdir -p /app/audio
+rm -f /app/audio/stream
 mkfifo -m a+rw /app/audio/stream
 while true; do cat /app/audio/stream | aplay $FORMAT; done &

--- a/setup-files/squeeze.sh
+++ b/setup-files/squeeze.sh
@@ -1,5 +1,10 @@
+#!/bin/bash
+
 if [ "$SQUEEZE" == "1" ]; then
-    mv -vn /app/squeeze.conf /app/ledfx-config/
+    mkdir -p /app/ledfx-config
+    if [[ -f /app/squeeze.conf ]]; then
+        cp -vn /app/squeeze.conf /app/ledfx-config/
+    fi
     cp -v /app/ledfx-config/squeeze.conf /etc/default/squeezelite
     /etc/init.d/squeezelite start
 fi


### PR DESCRIPTION
This PR updates the maintained Docker image path without changing the upstream Docker Hub image target.

Changes:
- Move the main image to Debian 13 / trixie.
- Install Python dependencies in a virtualenv to avoid root pip/system package conflicts.
- Update Snapcast package selection for trixie and fix the arm64 architecture mapping.
- Route Snapcast audio through PulseAudio so LedFx reactive effects can use the stream.
- Make startup scripts idempotent across container restarts.
- Update the Docker Hub latest workflow to build amd64/arm64, avoid pushing on PRs, and use GitHub Actions cache.

Not included here:
- No GHCR publishing changes.
- No fork-specific README changes.